### PR TITLE
edited match condition for "okay"

### DIFF
--- a/index.html
+++ b/index.html
@@ -183,7 +183,7 @@ function score_row(row) {
       win = false;
       row[i].className = 'bad';
       for (var j = 0; j < puzzle.length; j++) {
-        if (row[i].dataset.guess == puzzle[j].mid) row[i].className = 'okay';
+        if (row[i].dataset.guess == puzzle[j].mid && row[i].dataset.guess != puzzle[i].mid) row[i].className = 'okay';
       }
     }
   }


### PR DESCRIPTION
if guess word contains a letter in two places, one in correct spot and the other in an incorrect spot currently it marks one as green and other as yellow

this fix will consider such a matching case to be a "bad" rather than "okay"

e.g.
hidden word = pr dha n
guess word = pr ka r
current coloring = green red yellow
after fix = green red red