### PR TITLE
Fix issue where a letter is considered 'okay' when it exists twice an…

### DIFF
--- a/index.html
+++ b/index.html
@@ -123,6 +123,7 @@ footer {
 var wl = [];
 var rows = [];
 var puzzle = null;
+var letterCount = {};
 var now_utc = new Date();
 var todays_utc_date = now_utc.getUTCFullYear() + '-' + (now_utc.getUTCMonth() + 1) + '-' + now_utc.getUTCDate();
 
@@ -209,21 +210,28 @@ function score_row(row) {
   for (var i = 0; i < row.length; i++) {
     if (row[i].dataset.guess == puzzle[i].mid) {
       row[i].className = 'good';
+      letterCount[puzzle[i].mid] -= 1;
       key_map[row[i].dataset.guess].className = 'okay';
-    } else {
+    } 
+  }
+
+  for (var i = 0; i < row.length; i++) {
+    if(row[i].dataset.guess != puzzle[i].mid){
       win = false;
       row[i].className = 'bad';
       for (var j = 0; j < puzzle.length; j++) {
-        if (row[i].dataset.guess == puzzle[j].mid) {
+        if (row[i].dataset.guess == puzzle[j].mid && letterCount[puzzle[j].mid] > 0) {
           row[i].className = 'okay';
+          letterCount[puzzle[i].mid] -= 1;
           key_map[row[i].dataset.guess].className = 'okay';
         }
       }
       if (row[i].className == 'bad') {
         key_map[row[i].dataset.guess].className = 'bad';
       }
-    }
+    }    
   }
+
   if (win) make_share();
   else add_row();
 }
@@ -331,6 +339,11 @@ window.addEventListener('load', function() {
       }
       if (c == AKSHAR_POORA) {
         puzzle[puzzle.length - 1].mid = word.charAt(i);
+        if(word.charAt(i) in letterCount) {
+          letterCount[word.charAt[i]]++;
+        } else {
+          letterCount[word.charAt[i]] = 1; 
+        }
       }
 
       if (c == AKSHAR_POORA || (c == AKSHAR_MATRA && word.charCodeAt(i) != 0x094d))


### PR DESCRIPTION
…d the other instance is 'good'

The correct behavior is to mark it as 'bad'

The current logic just checks the presence to mark something as 'okay'.

The fix prevents this case from happening

Here are screenshots that illustrate the fix better:

Assuming the word to be guessed is: पदार्थ

**Before**
<img width="367" alt="Screen Shot 2022-02-11 at 11 36 02 AM" src="https://user-images.githubusercontent.com/1813269/153590516-0b604faa-c383-4c60-8b92-49bdd6e593af.png">

The second letter should not be marked as 'okay'

**After**
<img width="528" alt="Screen Shot 2022-02-11 at 11 44 32 AM" src="https://user-images.githubusercontent.com/1813269/153590585-ab8a31a7-828f-4a68-a24b-b8e807a72a11.png">



The one caveat is that the keyboard letter is currently marked as 'bad'; would love to confirm what the expected behavior is.