### PR TITLE
Added number of attempts/guesses count in shabdle scorecard

### DIFF
--- a/index.html
+++ b/index.html
@@ -771,6 +771,7 @@ function make_share() {
     'invalid': '⚫'
   }
   var out = "My Shabdle scorecard on " + todays_utc_date + ":\n";
+  out += "\nSolved in " + rows.length + " attempt[s].\n\n";
   for (var i = 0; i < rows.length; i++) {
     for (var j = 0; j < rows[i].length; j++) {
       out += tags[rows[i][j].className];


### PR DESCRIPTION
This pull request adds the number of attempts/guesses count in the shabdle scorecard.

Currently the score card does not display the number of guesses user has made.
Me and my family have been playing Shabdle for a long time now, and we share our shabdle attempts daily with each other. Sometimes it becomes difficult to count them when the attempts exceed 20!

Thanks for considering the pull request.
Let me know if you have any feedback or suggestions.

The change looks like below :
<img width="665" alt="Screenshot 2023-04-11 at 1 34 17 PM" src="https://user-images.githubusercontent.com/52616928/231285115-dc303eb8-d5c7-4d62-9d6c-5752c39bfdfb.png">
